### PR TITLE
Fix Error with status and show reconnecting when country is changed

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,6 @@ const PopupMenu = imports.ui.popupMenu;
 const Lang      = imports.lang;
 const GLib      = imports.gi.GLib;
 const Mainloop  = imports.mainloop;
-const ByteArray = imports.byteArray;    
 
 // Commands to run
 const CMD_VPNSTATUS  = "nordvpn status";
@@ -93,7 +92,7 @@ const VpnIndicator = new Lang.Class({
     _buildCountrySelector() {
         const cPopupMenuExpander = new PopupMenu.PopupSubMenuMenuItem('Countries');
         const [ok, standardOut, standardError, exitStatus] = GLib.spawn_command_line_sync("nordvpn countries");
-        const countries = ByteArray.toString(standardOut).replace(/\s+/g,' ').split(' ');
+        const countries = standardOut.toString().replace(/\s+/g,' ').split(' ');
         countries.sort();
 
         for (var i=3; i<countries.length; i++) {
@@ -154,7 +153,7 @@ const VpnIndicator = new Lang.Class({
         const [ok, standardOut, standardError, exitStatus] = GLib.spawn_command_line_sync(CMD_VPNSTATUS);
 
         // Convert Uint8Array object to string and split up the different messages
-        const statusMessages = ByteArray.toString(standardOut).split('\n');
+        const statusMessages = standardOut.toString().split('\n');
 
         // Check to see if a new version is available and display message in menu if so
         const updateAvailableText = statusMessages[0].includes('new version')
@@ -163,7 +162,8 @@ const VpnIndicator = new Lang.Class({
 
         // Determine the correct state from the "Status: xxxx" line
         // TODO: use results from vpn command to give details of error
-        let vpnStatus = _states[statusMessages[0]] || _states.ERROR;
+        let status = statusMessages[0].replace("\r-\r  \r\r-\r  \r","")
+        let vpnStatus = _states[status] || _states.ERROR;
 
         // If a state override is active, increment it and override the state if appropriate
         if (_stateOverride) {
@@ -180,7 +180,7 @@ const VpnIndicator = new Lang.Class({
         }
 
         // Update the menu and panel based on the current state
-        this._updateMenu(vpnStatus, statusMessages[0], updateAvailableText);
+        this._updateMenu(vpnStatus, status, updateAvailableText);
         this._updatePanel(vpnStatus, statusMessages);
 
         // Start the refreshes again


### PR DESCRIPTION
The extension did not work for me with Gnome shell 3.28.4 on Ubuntu 18.04 

It seems to be an issue with ByteArray.toString probably

I've also made change to override status as soon as country is clicked.